### PR TITLE
Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ ctx.set(Symbol.create(STTLWriter.SYMBOLS_NS + "complexPredicatesPriorities"), pr
 ctx.set(Symbol.create(STTLWriter.SYMBOLS_NS + "nsBaseIndent"), 4);
 // the minimal predicate width, defaults to 14
 ctx.set(Symbol.create(STTLWriter.SYMBOLS_NS + "predicateBaseWidth"), 14);
+// longest length for subject to be on the same line with the predicate, defaults to 20
+ctx.set(Symbol.create(STTLWriter.SYMBOLS_NS + "longSubject"), 20);
+// put multiple objects on separate lines each, defaults to false
+ctx.set(Symbol.create(STTLWriter.SYMBOLS_NS + "objectsMultiLine"), false);
+// put final dot on new line for named subjects, defaults to false
+ctx.set(Symbol.create(STTLWriter.SYMBOLS_NS + "namedDotNewLine"), false);
 Graph g = ... ; // fetch the graph you want to write
 RDFWriter w = RDFWriter.create().source().context(ctx).lang(sttl).build();
 w.output( ... ); // write somewhere

--- a/src/main/java/io/bdrc/jena/sttl/STriGWriter.java
+++ b/src/main/java/io/bdrc/jena/sttl/STriGWriter.java
@@ -1,11 +1,7 @@
 package io.bdrc.jena.sttl;
 
 import org.apache.jena.atlas.io.IndentedWriter;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.LangBuilder;
-import org.apache.jena.riot.RDFFormat;
-import org.apache.jena.riot.RDFLanguages;
-import org.apache.jena.riot.RDFWriterRegistry;
+import org.apache.jena.riot.*;
 import org.apache.jena.riot.system.PrefixMap;
 import org.apache.jena.riot.writer.TriGWriterBase;
 import org.apache.jena.sparql.core.DatasetGraph;
@@ -53,7 +49,7 @@ public class STriGWriter extends TriGWriterBase {
     public static Lang registerWriter(String langName, String contentType) {
         if (lang != null) return lang;
         lang = LangBuilder.create(langName, contentType).build();
-        RDFLanguages.register(lang);
+        RDFParserRegistry.registerLangQuads(lang, RDFParserRegistry.getFactory(Lang.TRIG));
         RDFFormat format = new RDFFormat(lang);
         RDFWriterRegistry.register(lang, format);
         RDFWriterRegistry.register(format, new STriGWriterFactory());


### PR DESCRIPTION
if you want I have 4 more changes, but feel free to reject them as well as added code can be a maintenance burden!

the first patch makes riot --pretty strig work, this somehow depends on going through the parser registry

the other patch adds 3 new symbols for even more custom pretty printed stable turtle files; the defaults are not touched of course

ex.
longSubject=0
```
:myApple
    a               :Apple .
```

objectsMultiLine=true
```
:myApple  :color
            :Green ,
            :Red .
```

namedDotNewLine=true
```
:myApple  a         :Apple ;
    :color          :Green
.
```